### PR TITLE
Autofix alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ankitdhall/torchsmith/security/code-scanning/1](https://github.com/ankitdhall/torchsmith/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since this workflow is a basic CI pipeline for running tests, it only requires read access to the repository contents. We will set `contents: read` as the minimal required permission. This change ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
