### PR TITLE
chore: Set version upper bound for HuggingFace datsaets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,9 @@ dependencies = [
     "torchvision>=0.19.1",
     "scipy>=1.15.2",
     "einops>=0.8.0",
-    "datasets>=3.3.2",
+    # Restricting to <=3.6.0 due breaking change (scripts not supported:
+    # arctic monkeys dataset loading fails)
+    "datasets>=3.3.2,<=3.6.0",
     "pre-commit>=4.1.0",
     "matplotlib>=3.10.0",
     "joblib>=1.4.2",


### PR DESCRIPTION
Restricting to <=3.6.0 due to breaking change (scripts not supported: arctic monkeys dataset loading fails)
See https://github.com/huggingface/datasets/releases/tag/4.0.0