### PR TITLE
chore: Replace torch's .reshape(...) usages with .view(...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -811,7 +811,7 @@ pre-commit run --all-files
 - [x] Add wandb support
 - [ ] Train on larger datasets
 - [ ] Experiment with different positional embeddings
-- [ ] Replace .reshape with .view in the codebase; see [ref.](https://stackoverflow.com/questions/49643225/whats-the-difference-between-reshape-and-view-in-pytorch)
+- [x] Replace .reshape with .view in the codebase; see [ref.](https://stackoverflow.com/questions/49643225/whats-the-difference-between-reshape-and-view-in-pytorch)
 
 
 ## Acknowledgements

--- a/src/torchsmith/models/diffusion/diffusion.py
+++ b/src/torchsmith/models/diffusion/diffusion.py
@@ -28,7 +28,7 @@ class DiffusionModel(torch.nn.Module):
     def sample_noise(self, num_samples: int) -> torch.Tensor:
         noise = self.normal_distribution.sample((num_samples,)).to(device=device)
         if isinstance(self.input_shape, tuple):
-            noise = noise.reshape((num_samples, *self.input_shape))
+            noise = noise.view((num_samples, *self.input_shape))
         return noise
 
     @staticmethod

--- a/src/torchsmith/models/diffusion/dit.py
+++ b/src/torchsmith/models/diffusion/dit.py
@@ -33,10 +33,10 @@ class PositionalEncoding2D(torch.nn.Module):
         grid = torch.meshgrid(position_w, position_h)  # Row-major ordering.
         grid = torch.stack(grid, dim=0)  # (2, grid_size, grid_size)
         encoding_w = self.get_1d_encoding(
-            num_dims=dim_model // 2, positions=grid[0].reshape(-1)
+            num_dims=dim_model // 2, positions=grid[0].view(-1)
         )
         encoding_h = self.get_1d_encoding(
-            num_dims=dim_model // 2, positions=grid[1].reshape(-1)
+            num_dims=dim_model // 2, positions=grid[1].view(-1)
         )
         self.register_buffer(
             "encoding", torch.cat([encoding_w, encoding_h], dim=-1).to(device)
@@ -44,7 +44,7 @@ class PositionalEncoding2D(torch.nn.Module):
 
     def get_1d_encoding(self, num_dims: int, positions: torch.Tensor) -> torch.Tensor:
         assert len(positions.shape) == 1
-        positions = positions.reshape((-1, 1))  # positions: (num_positions, 1)
+        positions = positions.view((-1, 1))  # positions: (num_positions, 1)
         half_dim = num_dims // 2
         i = torch.arange(0, half_dim).float()
         denominator = torch.pow(self.max_len, (i / half_dim))  # (dim_model/2,)
@@ -74,13 +74,15 @@ def get_2d_sincos_pos_embed_from_grid(embed_dim: int, grid) -> torch.Tensor:
     return emb
 
 
-def get_1d_sincos_pos_embed_from_grid(embed_dim: int, pos) -> torch.Tensor:
+def get_1d_sincos_pos_embed_from_grid(
+    embed_dim: int, pos: torch.Tensor
+) -> torch.Tensor:
     assert embed_dim % 2 == 0
     omega = torch.arange(embed_dim // 2, dtype=torch.float64)
     omega /= embed_dim / 2.0
     omega = 1.0 / 10000**omega  # (D/2,)
 
-    pos = pos.reshape(-1)  # (M,)
+    pos = pos.view(-1)  # (M,)
     out = torch.einsum("m,d->md", pos, omega)  # (M, D/2), outer product
 
     emb_sin = torch.sin(out)  # (M, D/2)
@@ -96,7 +98,7 @@ def get_2d_sincos_pos_embed(embed_dim: int, grid_size: int) -> torch.Tensor:
     grid = torch.meshgrid(grid_w, grid_h)  # here w goes first
     grid = torch.stack(grid, dim=0)
 
-    grid = grid.reshape([2, 1, grid_size, grid_size])
+    grid = grid.view([2, 1, grid_size, grid_size])
     pos_embed = get_2d_sincos_pos_embed_from_grid(embed_dim, grid)
     return pos_embed
 
@@ -298,7 +300,7 @@ class DiT(torch.nn.Module):
             x
         )  # (B, C, H, W) -> (B, D, H // patch_size, W // patch_size)
         batch_size = x.shape[0]
-        x = x.reshape(batch_size, self.dim_model, -1)  # (B, D, num_patches)
+        x = x.view(batch_size, self.dim_model, -1)  # (B, D, num_patches)
         x = x.permute(0, 2, 1)  # (B, D, num_patches) -> (B, num_patches, D)
         x = self.positional_embeddings(x)
 

--- a/src/torchsmith/models/external/_quantizer.py
+++ b/src/torchsmith/models/external/_quantizer.py
@@ -19,7 +19,7 @@ class VectorQuantizer(nn.Module):
     """
 
     def __init__(self, n_e, e_dim, beta):
-        super(VectorQuantizer, self).__init__()
+        super().__init__()
         self.n_e = n_e
         self.e_dim = e_dim
         self.beta = beta

--- a/src/torchsmith/models/external/_vqvae.py
+++ b/src/torchsmith/models/external/_vqvae.py
@@ -7,6 +7,7 @@ Taken with import modifications to be able to load the colored MNIST pre-trained
 import numpy as np
 import torch
 import torch.nn as nn
+
 from torchsmith.models.external._decoder import Decoder
 from torchsmith.models.external._encoder import Encoder
 from torchsmith.models.external._quantizer import VectorQuantizer
@@ -42,7 +43,7 @@ class VQVAE(nn.Module):
         self.n_embeddings = n_embeddings
         self.embedding_dim = embedding_dim
 
-    def quantize(self, x: np.ndarray) -> np.ndarray:
+    def quantize(self, x: np.ndarray) -> torch.Tensor:
         """Quantize an image x.
 
         Args:

--- a/src/torchsmith/models/flow/data/utils.py
+++ b/src/torchsmith/models/flow/data/utils.py
@@ -45,7 +45,7 @@ def plot_density(
     x = torch.linspace(-scale, scale, bins).to(device)
     y = torch.linspace(-scale, scale, bins).to(device)
     X, Y = torch.meshgrid(x, y)
-    xy = torch.stack([X.reshape(-1), Y.reshape(-1)], dim=-1)
+    xy = torch.stack([X.view(-1), Y.view(-1)], dim=-1)
     log_density = density.log_density(xy).view(bins, bins).T
     ax.imshow(
         log_density.cpu(),

--- a/src/torchsmith/models/flow/data/utils.py
+++ b/src/torchsmith/models/flow/data/utils.py
@@ -46,7 +46,7 @@ def plot_density(
     y = torch.linspace(-scale, scale, bins).to(device)
     X, Y = torch.meshgrid(x, y)
     xy = torch.stack([X.reshape(-1), Y.reshape(-1)], dim=-1)
-    log_density = density.log_density(xy).reshape(bins, bins).T
+    log_density = density.log_density(xy).view(bins, bins).T
     ax.imshow(
         log_density.cpu(),
         extent=(-scale, scale, -scale, scale),

--- a/src/torchsmith/models/flow/data/utils.py
+++ b/src/torchsmith/models/flow/data/utils.py
@@ -45,7 +45,7 @@ def plot_density(
     x = torch.linspace(-scale, scale, bins).to(device)
     y = torch.linspace(-scale, scale, bins).to(device)
     X, Y = torch.meshgrid(x, y)
-    xy = torch.stack([X.view(-1), Y.view(-1)], dim=-1)
+    xy = torch.stack([X.reshape(-1), Y.reshape(-1)], dim=-1)
     log_density = density.log_density(xy).view(bins, bins).T
     ax.imshow(
         log_density.cpu(),

--- a/src/torchsmith/models/flow/visualize.py
+++ b/src/torchsmith/models/flow/visualize.py
@@ -413,7 +413,7 @@ def visualize_field_across_time_and_space(
     xs = torch.linspace(-plot_limits, plot_limits, num_bins).to(device)
     ys = torch.linspace(-plot_limits, plot_limits, num_bins).to(device)
     xx, yy = torch.meshgrid(xs, ys)
-    xx = xx.reshape(-1, 1)
+    xx = xx.view(-1, 1)
     yy = yy.view(-1, 1)
     xy = torch.cat([xx, yy], dim=-1)
 

--- a/src/torchsmith/models/flow/visualize.py
+++ b/src/torchsmith/models/flow/visualize.py
@@ -414,7 +414,7 @@ def visualize_field_across_time_and_space(
     ys = torch.linspace(-plot_limits, plot_limits, num_bins).to(device)
     xx, yy = torch.meshgrid(xs, ys)
     xx = xx.reshape(-1, 1)
-    yy = yy.reshape(-1, 1)
+    yy = yy.view(-1, 1)
     xy = torch.cat([xx, yy], dim=-1)
 
     for t_index in range(num_marginals):

--- a/src/torchsmith/models/vae/vae_conv.py
+++ b/src/torchsmith/models/vae/vae_conv.py
@@ -79,7 +79,7 @@ class DecoderConv(nn.Module):
         self.model = nn.Sequential(*layers)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        fc_output = self.fc(x).reshape(-1, *self.decoder_input_shape)
+        fc_output = self.fc(x).view(-1, *self.decoder_input_shape)
         return self.model(fc_output)
 
 

--- a/src/torchsmith/models/vae/vae_fc.py
+++ b/src/torchsmith/models/vae/vae_fc.py
@@ -38,7 +38,7 @@ class MLP(nn.Module):
         self.model = nn.Sequential(*layers)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x = x.reshape(-1, self.input_dim)
+        x = x.view(-1, self.input_dim)
         output = self.model(x)
         return output.view(-1, *self.output_shape)
 

--- a/src/torchsmith/models/vae/vae_fc.py
+++ b/src/torchsmith/models/vae/vae_fc.py
@@ -40,7 +40,7 @@ class MLP(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = x.reshape(-1, self.input_dim)
         output = self.model(x)
-        return output.reshape(-1, *self.output_shape)
+        return output.view(-1, *self.output_shape)
 
 
 @add_save_load

--- a/src/torchsmith/tokenizers/mnist_tokenizer.py
+++ b/src/torchsmith/tokenizers/mnist_tokenizer.py
@@ -26,9 +26,7 @@ class VQVAEMNIST(BaseVQVAE):
         self.vqvae = load_pretrain_vqvae().eval().to(device)
 
     def encode_to_indices(self, x: torch.Tensor) -> torch.Tensor:
-        return cast(
-            torch.Tensor, self.vqvae.quantize(x.numpy()).reshape(x.shape[0], -1)
-        )
+        return cast(torch.Tensor, self.vqvae.quantize(x.numpy()).view(x.shape[0], -1))
 
     def decode_from_indices(self, x: torch.Tensor) -> torch.Tensor:
         with torch.no_grad():

--- a/src/torchsmith/tokenizers/vqvae_tokenizer.py
+++ b/src/torchsmith/tokenizers/vqvae_tokenizer.py
@@ -56,7 +56,7 @@ class VQVAEImageTokenizer(BaseTokenizer[TokenType]):
     def image_to_sequence(self, x: np.ndarray) -> np.ndarray:
         return (
             self.vqvae.encode_to_indices(torch.tensor(x, device=device))
-            .reshape(x.shape[0], -1)
+            .view(x.shape[0], -1)
             .cpu()
             .numpy()
         )


### PR DESCRIPTION
This PR replaces torch's `.reshape(...)` usages with `.view(...)`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced various tensor reshape operations with view-based operations to improve memory behavior and reduce unnecessary copies.
  * Modernized class initialization to Python 3-style super() usage.

* **Public API Changes**
  * VQVAE.quantize() now returns a PyTorch tensor instead of a NumPy array.

* **Documentation**
  * TODO item "Replace .reshape with .view in the codebase" marked complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->